### PR TITLE
986 fixed PosixPath drop support context manager

### DIFF
--- a/spinta/utils/path.py
+++ b/spinta/utils/path.py
@@ -1,8 +1,5 @@
-import atexit
-import importlib.resources
 import pathlib
-from contextlib import ExitStack
-from pathlib import Path
+from importlib import resources, abc
 
 
 def is_ignored(rules, base, path):
@@ -28,6 +25,5 @@ def is_ignored(rules, base, path):
     return False
 
 
-def resource_filename(package: str, target: str) -> Path:
-    with importlib.resources.files(package) / target as ref:
-        return ref
+def resource_filename(package: str, target: str) -> abc.Traversable:
+    return resources.files(package).joinpath(target)


### PR DESCRIPTION
fixed a bug "spinta --version" on Python3.13
removed unused imports